### PR TITLE
fix: client crash when used with RaidOverhaul or SkillsExtended mods

### DIFF
--- a/RSR_Observed_Component.cs
+++ b/RSR_Observed_Component.cs
@@ -44,7 +44,7 @@ namespace StanceReplication
 
         private void Update()
         {
-                
+
             /* 
              
              Issue Raised by Traveller
@@ -60,7 +60,7 @@ namespace StanceReplication
             Class362:UnityEngine.ILogHandler.LogException(Exception, Object)
             UnityEngine.Debug:CallOverridenDebugHandler(Exception, Object)
             */
-            
+
             /*
              * Notes:
              * From Fontaine on Fika Discord
@@ -74,15 +74,20 @@ namespace StanceReplication
              * This stack trace provided by Traveler did occur in Primal-13's playgroup as well
              * But only when the match was loading. Errors did stop eventually and it was noted that the individual was experiencing alot of packet loss
              */
-            
-            
+
+
+            if (_observedCoopPlayer == null)
+            {
+                return;
+            }
+
             ProceduralWeaponAnimation pwa = _observedCoopPlayer.ProceduralWeaponAnimation;
-            
-            
+
+
             if (_observedCoopPlayer.IsSprintEnabled || !_observedCoopPlayer.ProceduralWeaponAnimation.OverlappingAllowsBlindfire)
             {
                 _cancelStanceTimer += Time.deltaTime;
-                if(_cancelStanceTimer >= Plugin.CancelTimer.Value)
+                if (_cancelStanceTimer >= Plugin.CancelTimer.Value)
                 {
                     _allowStanceTimer = 0f;
                     _canUpdateStance = false;
@@ -114,7 +119,7 @@ namespace StanceReplication
                 pwa.HandsContainer.HandsPosition.Zero = pwa.PositionZeroSum + _targetPosition * pwa.Single_3 * 1.5f;
                 pwa.HandsContainer.WeaponRootAnim.rotation = Quaternion.Slerp(pwa.HandsContainer.WeaponRootAnim.rotation, _targetRotation, 1f);
             }
-            else 
+            else
             {
                 doPatrol = false;
                 _targetPosition = Vector3.Lerp(_targetPosition, Vector3.zero, 0.5f);
@@ -129,8 +134,8 @@ namespace StanceReplication
         {
             _packetPosition = weapPos;
             _packetRotation = rot;
-            _isPatrol  = patrol;
-            sprintAnim = anim;  
+            _isPatrol = patrol;
+            sprintAnim = anim;
 
         }
     }


### PR DESCRIPTION
Hello there, with @devilflippy we experimented some client crashes on start when combining this mod with [`RaidOverhaul`](https://github.com/KillerDJLang/Raid-Overhaul) and [`SkillsExtended`](https://github.com/CJ-SPT/Skills-Extended) so I just added some defensive code here to prevent this crash happens.

Here is some stacktraces:

```
NullReferenceException: Object reference not set to an instance of an object
  at RaidOverhaul.Plugin.Update () [0x000b1] in <dc353451ee5b40998a4a1765f2e37d92>:0 
UnityEngine.DebugLogHandler:Internal_LogException(Exception, Object)
UnityEngine.DebugLogHandler:LogException(Exception, Object)
Class362:UnityEngine.ILogHandler.LogException(Exception, Object)
UnityEngine.Logger:LogException(Exception, Object)
UnityEngine.Debug:CallOverridenDebugHandler(Exception, Object)
```

and 

```
NullReferenceException: Object reference not set to an instance of an object
  at SkillsExtended.Plugin.Update () [0x0000c] in <c190b01f3b3145a4b668a563d02176c0>:0 
UnityEngine.DebugLogHandler:Internal_LogException(Exception, Object)
UnityEngine.DebugLogHandler:LogException(Exception, Object)
Class362:UnityEngine.ILogHandler.LogException(Exception, Object)
UnityEngine.Logger:LogException(Exception, Object)
UnityEngine.Debug:CallOverridenDebugHandler(Exception, Object)
 
(Filename: <c190b01f3b3145a4b668a563d02176c0> Line: 0)
```

----

I don't have tested it in-raid yet but it should be ok I think. We can wait for confirmation before merging this PR.
if someone want to test, here is a build -> https://github.com/guillaumearm/Realism-Stance-Replication/releases/tag/v1.1.1-trap

----

Other changes:
- remove some extra spaces in `RSR_Observed_Component.cs` file

# TODOs
- [x] test that the replication still work as intended using `RSR` + `RaidOverhaul` + `SkillsExtended` mods
